### PR TITLE
Return FixedTimerKey from at! and after! macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -377,14 +377,14 @@ macro_rules! generic_call {
          let cx: &mut $crate::Cx<'_, Self> = $cx;  // Expecting Cx<Self> ref
          let this = cx.this().clone();
          let core = $cx.access_core();
-         $crate::$handler!($hargs core; move |s| this.apply(s, cb));
+         $crate::$handler!($hargs core; move |s| this.apply(s, cb))
      }};
     ($handler:ident $hargs:tt $access:ident;
      [$core:expr], |$stakker:pat_param| $body:expr) => {{
          $crate::COVERAGE!(generic_call_1);
          let core = $core.$access();  // Expecting Core, Cx or Stakker ref
          let cb = move |$stakker : &mut $crate::Stakker| $body;
-         $crate::$handler!($hargs core; cb);
+         $crate::$handler!($hargs core; cb)
      }};
     ($handler:ident $hargs:tt $access:ident;
      [$cx:expr], move | $($x:tt)*) => {{
@@ -664,7 +664,7 @@ macro_rules! after {
 macro_rules! after_aux {
     (($dur:ident) $core:ident; $cb:expr) => {{
         $crate::COVERAGE!(after_1);
-        $core.after($dur, $cb);
+        $core.after($dur, $cb)
     }};
 }
 


### PR DESCRIPTION
The documentation for the at! and after! macros describe that they are supposed to return a FixedTimerKey. However, due to extraneous semicolons in the two closure-specific generic_call! macro branches, as well as a semicolon in the after_aux! macro, the at! macro did not return a FixedTimerKey when used with closures, and the after! macro never returned a FixedTimerKey. This PR removes those three semicolons.