### PR TITLE
Support wasm by conditionally using the web_time crate in order to support Instant and SystemTime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,3 +55,6 @@ logger = []
 
 # Ignored for backwards-compatibility.  `anymap` is now always enabled
 anymap = []
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "1.1.0"

--- a/src/core.rs
+++ b/src/core.rs
@@ -12,7 +12,11 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt::Arguments;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use std::time::{Duration, Instant, SystemTime};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::{Instant, SystemTime};
+#[cfg(target_family = "wasm")]
+use web_time::{Instant, SystemTime};
 
 /// The external interface to the actor runtime
 ///

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -693,7 +693,10 @@ macro_rules! after_aux {
 macro_rules! at {
     ( $inst:expr, $($x:tt)+ ) => {{
         $crate::COVERAGE!(at_0);
+        #[cfg(not(target_family = "wasm"))]
         let inst: std::time::Instant = $inst;
+        #[cfg(target_family = "wasm")]
+        let inst: web_time::Instant = $inst;
         $crate::generic_call!(at_aux (inst) access_core; $($x)+) // Error? Try [actor, core] form
     }};
 }
@@ -745,7 +748,10 @@ macro_rules! timer_max {
     ( $var:expr, $inst:expr, $($x:tt)+ ) => {{
         $crate::COVERAGE!(timer_max_0);
         let var: &mut $crate::MaxTimerKey = $var;
+        #[cfg(not(target_family = "wasm"))]
         let inst: std::time::Instant = $inst;
+        #[cfg(target_family = "wasm")]
+        let inst: web_time::Instant = $inst;
         $crate::generic_call!(timer_max_aux (var, inst) access_core; $($x)+) // Error? Try [actor, core] form
     }};
 }
@@ -799,7 +805,10 @@ macro_rules! timer_min {
     ( $var:expr, $inst:expr, $($x:tt)+ ) => {{
         $crate::COVERAGE!(timer_min_0);
         let var: &mut $crate::MinTimerKey = $var;
+        #[cfg(not(target_family = "wasm"))]
         let inst: std::time::Instant = $inst;
+        #[cfg(target_family = "wasm")]
+        let inst: web_time::Instant = $inst;
         $crate::generic_call!(timer_min_aux (var, inst) access_core; $($x)+) // Error? Try [actor, core] form
     }};
 }

--- a/src/test/actor.rs
+++ b/src/test/actor.rs
@@ -1,6 +1,10 @@
 use crate::actor::StringError;
 use crate::*;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 test_fn!(
     fn actor_termination() {

--- a/src/test/core.rs
+++ b/src/test/core.rs
@@ -1,6 +1,10 @@
 use crate::*;
 use std::rc::Rc;
-use std::time::{Duration, Instant, SystemTime};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::{Instant, SystemTime};
+#[cfg(target_family = "wasm")]
+use web_time::{Instant, SystemTime};
 
 test_fn!(
     fn test_times() {

--- a/src/test/log.rs
+++ b/src/test/log.rs
@@ -90,7 +90,10 @@ test_fn!(
     #[cfg(feature = "logger")]
     fn logger() {
         use std::fmt::Arguments;
+        #[cfg(not(target_family = "wasm"))]
         use std::time::Instant;
+        #[cfg(target_family = "wasm")]
+        use web_time::Instant;
 
         let now = Instant::now();
         let mut stakker = Stakker::new(now);

--- a/src/test/macros.rs
+++ b/src/test/macros.rs
@@ -7,7 +7,11 @@ use crate::{
 };
 use std::cell::RefCell;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 #[derive(Clone)]
 struct Scores(Rc<RefCell<[u8; 100]>>);

--- a/src/test/memsizes.rs
+++ b/src/test/memsizes.rs
@@ -4,7 +4,10 @@
 //! have the allocation size show up in valgrind.
 
 use crate::{actor_new, ret_nop, ret_panic, ret_to, ActorOwn, Stakker, StopCause, CX};
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 #[allow(dead_code)]
 struct Actor0([u8; 0]);

--- a/src/test/queue_corpus.rs
+++ b/src/test/queue_corpus.rs
@@ -1,5 +1,8 @@
 use crate::*;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 // This uses a snapshot of a small fuzzing corpus that gives full
 // coverage of queue operations in `cargo fuzz`

--- a/src/test/share.rs
+++ b/src/test/share.rs
@@ -1,5 +1,8 @@
 use crate::*;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 test_fn!(
     fn share() {

--- a/src/test/task.rs
+++ b/src/test/task.rs
@@ -3,7 +3,10 @@ use crate::*;
 use std::cell::RefCell;
 use std::pin::Pin;
 use std::rc::Rc;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 // This tests the Task mechanism, but without needing async/await
 test_fn!(

--- a/src/test/thread.rs
+++ b/src/test/thread.rs
@@ -7,7 +7,10 @@ use crate::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 /// Simple channel for sending and waiting for notification events.
 /// Returns (send, recv) closures.  This means that we can simulate a

--- a/src/test/timers_corpus.rs
+++ b/src/test/timers_corpus.rs
@@ -2,7 +2,11 @@ use crate::*;
 use std::cell::RefCell;
 use std::collections::HashSet;
 use std::rc::Rc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 // This uses a snapshot of a small fuzzing corpus that gives full
 // coverage of fixed timer addition and execution in `cargo fuzz`

--- a/src/test/waker.rs
+++ b/src/test/waker.rs
@@ -13,7 +13,10 @@ use std::collections::HashSet;
 use std::rc::Rc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
+#[cfg(not(target_family = "wasm"))]
 use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 // Test it all in one thread so that we have total control over the
 // order of operations, to exercise many combinations but reliably and

--- a/src/timers/mod.rs
+++ b/src/timers/mod.rs
@@ -3,7 +3,11 @@ use std::cmp::Ordering;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::mem;
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(not(target_family = "wasm"))]
+use std::time::Instant;
+#[cfg(target_family = "wasm")]
+use web_time::Instant;
 
 // TODO: Switch to N-ary Heap for storing (WrapTime, slot-index),
 // e.g. Octonary heap, and use slots for normal timers as well as


### PR DESCRIPTION
Currently stakker can not be run on a browser, it fails at runtime with the following message

* time not implemented on this platform *

The web_time crate provides drop in replacement for std::time::Instant and SystemTime.

This PR is to conditionally switch from std::time to web_time for wasm targets.

The code compiles on both wasm and non wasm targets.

TODO run the tests on a wasm target.